### PR TITLE
OS-220 adding HttpOnly+Secure options

### DIFF
--- a/src/EventSubscriber/SimplesamlSubscriber.php
+++ b/src/EventSubscriber/SimplesamlSubscriber.php
@@ -57,7 +57,7 @@ class SimplesamlSubscriber implements EventSubscriberInterface {
     // If user is not anonymous, if SimpleSAML is not activated or if PHP_SAPI
     // is cli - don't do any redirects.
     if (!$this->account->isAnonymous() || !$this->simplesaml->isActivated() || PHP_SAPI === 'cli') {
-      //return;
+      return;
     }
 
     $request = $event->getRequest();


### PR DESCRIPTION
The OS2Web SimpleSAML Authentication module needs to be extended so that the cookie has HttpOnly set

HttpOnly is missing
is/are missing the "Secure" cookie attribute.